### PR TITLE
Remove hdf4 from essential libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
 - Renamed tarfile GitHub Action for consistency
+- Remove HDF4 from the essential libraries
 
 ### Removed
 ### Added


### PR DESCRIPTION
This PR does some clean up to remove HDF4 from the set of essential libs. It isn't really, and on aarch64 it has issues. We do remove it from that arch, but if you want to test on a x86 machine, it was hard to do without some edits. 