### PR TITLE
Fix for hdf5 build with nvhpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Updates
 ### Fixed
+
+- Fix for building HDF5 with nvhpc
+
 ### Changed
 ### Removed
 ### Added

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -508,7 +508,7 @@ hdf5.config :: hdf5/README.md szlib.install zlib.install
 	echo Configuring hdf5
 	(cd hdf5; \
           export PATH="$(prefix)/bin:$(PATH)" ;\
-          export LDFLAGS="-lm" ;\
+          export LIBS="-lm" ;\
           ./configure --prefix=$(prefix) \
                       --includedir=$(prefix)/include/hdf5 \
                       --with-szlib=$(prefix)/include/szlib,$(prefix)/lib \


### PR DESCRIPTION
Testing with nvhpc on Adapt using nvhpc modules from @cponder found a build issue where `LDFLAGS` was interfering with the `LD_LIBRARY_PATH` set by the modules.

Not sure why this happened now and not in the last forever years or whatever that line was there. But there you go.