### PR TITLE
Disable HDF4 Fortran with ifx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Updates
 ### Fixed
+
+- Disable HDF4 Fortran bindings when using `ifx` as `FC`
+  - This means we must also disable builds of HDF-EOS2 and SDPToolkit
+
 ### Changed
 ### Removed
 ### Added

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -197,6 +197,17 @@ RELEASE_FILE = $(MKFILE_DIRNAME)-$(DATE)
      export NO_INT_CONVERSION_ERROR
   endif
 
+# HDF4 plus ifx does not work with Fortran bindings
+# -------------------------------------------------
+
+  ifeq ($(findstring ifx,$(notdir $(FC))),ifx)
+     HDF4_ENABLE_FORTRAN := --disable-fortran
+     export HDF4_ENABLE_FORTRAN
+  else
+     HDF4_ENABLE_FORTRAN := --enable-fortran
+     export HDF4_ENABLE_FORTRAN
+  endif
+
 # HDF5 and MPT at NCCS have an "issue" that needs an extra flag
 # -------------------------------------------------------------
 
@@ -309,6 +320,14 @@ else
    LIB_HDF4 =
    # Also need to remove hdfeos if no hdf4
    SUBDIRS := $(filter-out hdfeos,$(SUBDIRS))
+endif
+
+# Since we do not build the Fortran interface
+# to HDF4 with ifx, we cannot build hdf-eos2
+# or SDPToolkit
+ifeq ($(findstring ifx,$(notdir $(FC))),ifx)
+   SUBDIRS := $(filter-out hdfeos,$(SUBDIRS))
+   SUBDIRS := $(filter-out SDPToolkit,$(SUBDIRS))
 endif
 
 TARGETS = all lib install
@@ -514,7 +533,7 @@ hdf4.config: hdf4/README.md jpeg.install zlib.install szlib.install
                       --with-zlib=$(prefix)/include/zlib,$(prefix)/lib \
                       --disable-netcdf \
                       --enable-hdf4-xdr \
-                      --enable-fortran \
+                      $(HDF4_ENABLE_FORTRAN) \
                       CFLAGS="$(CFLAGS) $(NO_IMPLICIT_FUNCTION_ERROR) $(NO_IMPLICIT_INT_ERROR)" FFLAGS="$(NAG_FCFLAGS) $(NAG_DUSTY) $(ALLOW_ARGUMENT_MISMATCH)" CC=$(CC) FC=$(FC) CXX=$(CXX) )
 	touch $@
 


### PR DESCRIPTION
Per @byrnHDF, the [HDF4 Fortran interface is deprecated](https://github.com/HDFGroup/hdf4/issues/4#issuecomment-1533581293). However, as GEOSldas still requires it, we build it in hopes we don't hit the 32/64 issue.

However, in my testing, even when `--enable-fortran` is set, with `ifx` HDF4 is *not* happy. `icx` throws a linker error or something. My guess is this is just due to age and until the HDF Group fixes up HDF4 + Fortran, it can't be depended on to ever work. 

So, for now, if `FC=ifx` we just turn off HDF4 Fortran. But since HDF-EOS2 depends on HDF4 Fortran and SDPToolkit depends on HDF-EOS2, we turn those off as well.