### PR TITLE
Move to canonical CMake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Updates
 ### Fixed
 ### Changed
+
+- Changed all CMake builds to be "canonical" (`cmake -B build -S .` and `cmake --build build`)
+
 ### Removed
 ### Added
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -629,8 +629,8 @@ udunits2.config : udunits2/configure.ac
 fortran_udunits2.config: udunits2.install
 	@echo "Configuring fortran_udunits2"
 	@mkdir -p ./fortran_udunits2/build
-	@(cd ./fortran_udunits2/build; \
-		cmake -DCMAKE_PREFIX_PATH=$(prefix) -DCMAKE_INSTALL_PREFIX=$(prefix) .. -DCMAKE_Fortran_COMPILER=$(NC_FC))
+	@(cd ./fortran_udunits2; \
+		cmake -B build -S . --install-prefix=$(prefix) -DCMAKE_PREFIX_PATH=$(prefix) -DCMAKE_Fortran_COMPILER=$(NC_FC))
 	@touch $@
 
 INC_HDF5 = $(prefix)/include/hdf5
@@ -758,23 +758,23 @@ nccmp.config: nccmp/configure netcdf.install
 xgboost.config:
 	@echo "Configuring xgboost"
 	@mkdir -p ./xgboost/build
-	@(cd ./xgboost/build; \
-		cmake -DCMAKE_INSTALL_PREFIX=$(prefix) .. )
+	@(cd ./xgboost; \
+		cmake -B build -S . --install-prefix=$(prefix) )
 	@touch $@
 
 GFE.config:
 	@echo "Configuring GFE"
 	@mkdir -p ./GFE/build
-	@(cd ./GFE/build; \
-		cmake -DCMAKE_INSTALL_PREFIX=$(prefix) -DCMAKE_PREFIX_PATH=$(prefix) -DSKIP_OPENMP=YES .. )
+	@(cd ./GFE; \
+		cmake -B build -S . --install-prefix=$(prefix) -DCMAKE_PREFIX_PATH=$(prefix) -DSKIP_OPENMP=YES )
 	@touch $@
 
 FLAP.config:
 	@echo "Configuring FLAP"
 	@mkdir -p $(prefix)/lib
 	@mkdir -p ./FLAP/build
-	@(cd ./FLAP/build; \
-		cmake -DCMAKE_INSTALL_PREFIX=$(prefix) .. )
+	@(cd ./FLAP; \
+		cmake -B build -S . --install-prefix=$(prefix) )
 	@touch $@
 
 antlr2.config : antlr2/configure
@@ -939,26 +939,26 @@ nccmp.install: nccmp.config
 
 fortran_udunits2.install: fortran_udunits2.config
 	@echo "Installing fortran_udunits2"
-	@(cd ./fortran_udunits2/build; \
-		$(MAKE) install )
+	@(cd ./fortran_udunits2; \
+		cmake --build build --target install -j 4)
 	@touch $@
 
 xgboost.install: xgboost.config
 	@echo "Installing xgboost"
-	@(cd ./xgboost/build; \
-		$(MAKE) install )
+	@(cd ./xgboost; \
+		cmake --build build --target install -j 4)
 	@touch $@
 
 GFE.install: GFE.config
 	@echo "Installing GFE"
-	@(cd ./GFE/build; \
-		$(MAKE) install )
+	@(cd ./GFE; \
+		cmake --build build --target install -j 4)
 	@touch $@
 
 FLAP.install: FLAP.config
 	@echo "Installing FLAP with CMake"
-	@(cd ./FLAP/build; \
-      $(MAKE) -j1 install )
+	@(cd ./FLAP; \
+		cmake --build build --target install -j 1)
 	@touch $@
 
 # MAT: Note that on Mac machines there seems to be an issue with the libtool setup
@@ -1175,9 +1175,9 @@ GFE.check: GFE.install
 	@echo "This requires a re-CMake to enable testing"
 	@rm -rf ./GFE/build
 	@mkdir -p ./GFE/build
-	@(cd ./GFE/build; \
-		cmake -DCMAKE_INSTALL_PREFIX=$(prefix) -DCMAKE_PREFIX_PATH=$(prefix) -DSKIP_OPENMP=YES .. ;\
-		$(MAKE) tests)
+	@(cd ./GFE; \
+		cmake -B build -S . --install-prefix=$(prefix) -DCMAKE_PREFIX_PATH=$(prefix) -DSKIP_OPENMP=YES ;\
+		cmake --build build --target tests -j 4)
 	@touch $@
 
 FLAP.check: FLAP.install


### PR DESCRIPTION
For reasons unknown to me (and @tclune), builds of GFE on bucy started...failing. It worked four times, but the fifth time...nope! The CMake started acting "wonky" like it was seeing more of the environment than it should have.

So, channeling @scivision, if we move Baselibs from:

```
cd ./package/build
cmake -DCMAKE_INSTALL_PREFIX=$(prefix) ..
```
to:
```
cd ./package
cmake -B build -S . --install-prefix=$(prefix)
```

the GFE build worked.

Now, as far as I know these do the same thing, but the first one failed, the second one worked. Why? 🤷🏼 But moving to "canonical" CMake is only a good thing.