### PR TITLE
Fixes for icx at NAS with MPT

### DIFF
--- a/Base.mk
+++ b/Base.mk
@@ -377,17 +377,9 @@ endif
 
   ifeq ($(ESMF_COMM),mpt)
     MPICC := mpicc
-    ifeq ($(findstring ifort,$(notdir $(FC))),ifort)
-      CC := gcc
-      CC_FROM_ENV := FALSE
-    endif
   endif
   ifeq ($(ESMF_COMM),mpt)
     MPICXX := mpicxx
-    ifeq ($(findstring ifort,$(notdir $(FC))),ifort)
-      CXX := g++
-      CXX_FROM_ENV := FALSE
-    endif
   endif
 
 # Make sure we have compilers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Updates
 ### Fixed
+
+- Fixes for MPT and using icx/icpx at NAS
+
 ### Changed
 ### Removed
 ### Added


### PR DESCRIPTION
Tests at NAS with icx/icpx found some 4 year old code that I don't think is necessary and actually interferes. So we remove code that says "if FC is ifort, CC is gcc" which is...weird.

Maybe this was from the days of bad `icc`? 🤷🏼 