### PR TITLE
Use mpif08 with mpt at NAS

### DIFF
--- a/Base.mk
+++ b/Base.mk
@@ -341,6 +341,15 @@
   ifeq ($(ESMF_COMM),openmpi)
     MPIFC := mpifort
   else
+  ifeq ($(ESMF_COMM),mpt)
+    ifneq ($(wildcard $(shell which mpif08 2> /dev/null)),)
+       MPIFC := mpif08
+    else
+    ifneq ($(wildcard $(shell which mpif90 2> /dev/null)),)
+       MPIFC := mpif90
+    endif
+    endif
+  else
   ifneq ($(wildcard $(shell which mpifort 2> /dev/null)),)
     MPIFC := mpifort
   else
@@ -348,6 +357,7 @@
     MPIFC := mpif90
   else
     MPIFC := $(FC)
+  endif
   endif
   endif
   endif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Updates
 ### Fixed
+
+- Building with GCC 14 + MPT on PFE showed the need to use `mpif08` when building HDF5. So, if `mpif08` is detected with MPT, we use
+  it as `MPIFC`
+
 ### Changed
 ### Removed
 ### Added


### PR DESCRIPTION
Testing at NAS with GCC 14 and MPT showed HDF5 needed to be built with `mpif08`.