### PR TITLE
v7: Turn off ESMPy building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Add support for flang-new
 
 ### Changed
+
+- Turn off ESMPy building. It's not working and maybe we don't want to
+  build from source anyway as it's easier through mamba
+
 ### Removed
 ### Added
 

--- a/esmf_rules.mk
+++ b/esmf_rules.mk
@@ -134,13 +134,11 @@ esmf.script_info script_info:
 esmf.check check:
 	@echo "Customized ESMF build step $@..."
 	@(cd $(ESMF_DIR); make -e check)
-	@(cd $(ESMF_DIR)/src/addon/esmpy; export PYTHONPATH=$(ESMF_INSTALL_PREFIX)/lib/python2.7/site-packages; $(ESMF_PYTHON) setup.py test)
 	@touch esmf.check
 
 esmf.all_tests all_tests:
 	@echo "Customized ESMF build step $@..."
 	@(cd $(ESMF_DIR); make -e all_tests)
-	@(cd $(ESMF_DIR)/src/addon/esmpy; export PYTHONPATH=$(ESMF_INSTALL_PREFIX)/lib/python2.7/site-packages; $(ESMF_PYTHON) setup.py test)
 	@touch esmf.all_tests
 
 esmf.examples:
@@ -167,19 +165,15 @@ ifeq ($(ARCH), Darwin)
 endif
 	@cp -pr $(ESMF_DIR)/cmake/*    $(ESMF_INSTALL_HEADERDIR)
 	@touch esmf.install
-	@(cd $(ESMF_DIR)/src/addon/esmpy; $(ESMF_PYTHON) setup.py build --ESMFMKFILE=$(ESMF_INSTALL_LIBDIR)/esmf.mk; $(ESMF_PYTHON) setup.py install --prefix=$(ESMF_INSTALL_PREFIX))
-	@touch esmf.python
 
-# There once was an Intel 16 bug fixed, the ESMF apps can be built separately
-esmf.python python: esmf.install
-	@echo "Customized ESMF build step $@..."
-	@(cd $(ESMF_DIR)/src/addon/esmpy; $(ESMF_PYTHON) setup.py build --ESMFMKFILE=$(ESMF_INSTALL_LIBDIR)/esmf.mk; $(ESMF_PYTHON) setup.py install --prefix=$(ESMF_INSTALL_PREFIX))
-	@touch esmf.python
+#esmf.python python: esmf.install
+	#@echo "Customized ESMF build step $@..."
+	#@(cd $(ESMF_DIR)/src/addon/esmpy; $(ESMF_PYTHON) setup.py build --ESMFMKFILE=$(ESMF_INSTALL_LIBDIR)/esmf.mk; $(ESMF_PYTHON) setup.py install --prefix=$(ESMF_INSTALL_PREFIX))
+	#@touch esmf.python
 
-# There once was an Intel 16 bug fixed, the ESMF apps can be built separately
-esmf.pythoncheck pythoncheck: esmf.install
-	@echo "Customized ESMF build step $@..."
-	@(cd $(ESMF_DIR)/src/addon/esmpy; export PYTHONPATH=$(ESMF_INSTALL_LIBDIR)/python2.7/site-packages; $(ESMF_PYTHON) setup.py test)
+#esmf.pythoncheck pythoncheck: esmf.install
+	#@echo "Customized ESMF build step $@..."
+	#@(cd $(ESMF_DIR)/src/addon/esmpy; export PYTHONPATH=$(ESMF_INSTALL_LIBDIR)/python2.7/site-packages; $(ESMF_PYTHON) setup.py test)
 
 %:
 	@echo "Customized ESMF build step $@..."


### PR DESCRIPTION
The ESMPy building via Baselibs was all sorts of broken. It's better to get through mamba now anyway.