### PR TITLE
Disable hdfeos, et al, when GCC 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Fix CMake issue with `GFE.check` target
 
 ### Changed
+
+- Disable builds of `hdfeos2`, `hdfeos5`, and `SDPToolkit` with GCC 14+. They don't seem to build at the moment and are not needed for GNU builds of GEOS
+
 ### Removed
 
 ### Added

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -170,6 +170,9 @@ MAKEJOBS := $(if $(MAKEJOBS),$(MAKEJOBS),1)
 	  # CDO needs C++20 standard
      CDO_STD := -std=c++20
      export CDO_STD
+
+     GFORTRAN_VERSION_GTE_14 := $(shell expr `$(FC) -dumpversion | cut -f1 -d.` \>= 14)
+     export GFORTRAN_VERSION_GTE_14
   endif
 
 # Clang has issues with some libraries due to strict C99
@@ -338,6 +341,14 @@ ifeq ($(MACH),aarch64)
    NO_ARM_DIRS = hdf4 hdfeos hdfeos5 SDPToolkit
    ALLDIRS := $(filter-out $(NO_ARM_DIRS),$(ALLDIRS))
    ESSENTIAL_DIRS := $(filter-out hdf4,$(ESSENTIAL_DIRS))
+endif
+
+# Apparently, GCC 14+ has an issue with hdfeos and hdfeos5 (and thus SDPToolkit)
+# This really only matters on Linux, but we will do it for all (since macOS will
+# alrealy strip these out)
+ifeq ($(GFORTRAN_VERSION_GTE_14),1)
+   NO_GCC14_DIRS = hdfeos hdfeos5 SDPToolkit
+   ALLDIRS := $(filter-out $(NO_GCC14_DIRS),$(ALLDIRS))
 endif
 
 ifeq ('$(BUILD)','ESSENTIALS')


### PR DESCRIPTION
This disables building of `hdfeos`, `hdfeos5` and `SDPToolkit` when building with GCC 14. It doesn't seem to work and GEOS doesn't need it with GNU at least.