### PR TITLE
v8: Add autoreconf >= 2.72 version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- `autoreconf` version 2.72 or higher is now required. The build will error out early if the system `autoreconf` does not meet this requirement.
+
 ### Removed
 
 ### Added

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -43,6 +43,12 @@ MAKEJOBS := $(if $(MAKEJOBS),$(MAKEJOBS),1)
     undefine CXX
   endif
 
+  AUTORECONF_VERSION := $(shell autoreconf --version 2>/dev/null | head -1 | sed 's/[^0-9.]//g' | cut -d. -f1-2)
+  AUTORECONF_VERSION_OK := $(shell awk 'BEGIN { exit ($(AUTORECONF_VERSION) >= 2.72) ? 0 : 1 }' && echo yes || echo no)
+  ifneq ($(AUTORECONF_VERSION_OK),yes)
+    $(error autoreconf version $(AUTORECONF_VERSION) is too old. Version 2.72 or higher is required.)
+  endif
+
   include Base.mk
   include Arch.mk
   include baselibs-config.mk
@@ -507,6 +513,7 @@ verify:
 	@echo ESMF_COMPILER = $(ESMF_COMPILER)
 	@echo ENABLE_HDF4 = $(ENABLE_HDF4)
 	@echo LIB_HDF4 = $(LIB_HDF4)
+	@echo AUTORECONF_VERSION = $(AUTORECONF_VERSION)
 	@echo MAKEJOBS = $(MAKEJOBS)
 	@echo SITE = $(SITE)
 	@ argv="$(SUBDIRS)" ;\

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ NASA/GSFC.
 
 - CMake v3.24 or higher
 
+- `autoreconf` (GNU Autoconf) v2.72 or higher
+
 ### Obtaining ESMA Baselibs
 
 ESMA Baselibs can be obtained in two ways via a tarball or through git.


### PR DESCRIPTION
## Summary

- Adds an early check in `GNUmakefile` that errors out if the system `autoreconf` is older than version 2.72
- Documents `autoreconf` v2.72+ as an explicit build requirement in `README.md`
- Notes the new requirement in `CHANGELOG.md` under `[Unreleased]`

Closes #364